### PR TITLE
fixes error in saxon 9.8 for node() compared to untypedAtomic

### DIFF
--- a/scripts/overrides/tei_to_solr.xsl
+++ b/scripts/overrides/tei_to_solr.xsl
@@ -636,7 +636,7 @@
 			<xsl:variable name="jurisdiction">
 				<xsl:value-of select="$org"/>
 				<xsl:choose>
-					<xsl:when test="not($place/text() = '')">
+					<xsl:when test="not(string($place/text()) = '')">
 						- 
 						<xsl:value-of select="$place"/>
 					</xsl:when>
@@ -898,7 +898,7 @@
 					<xsl:variable name="jurisdiction">
 						<xsl:value-of select="$org"/>
 						<xsl:choose>
-							<xsl:when test="not($place/text() = '')">
+							<xsl:when test="not(string($place/text()) = '')">
 								- 
 								<xsl:value-of select="$place"/>
 							</xsl:when>


### PR DESCRIPTION
addresses by making them strings to compare string with
as empty(node/text()) did not appear to detect when the node
existed but without content...!

closes https://github.com/CDRH/data_oscys/issues/42